### PR TITLE
#3 - Add request validations into pipeline and filters

### DIFF
--- a/API/API.csproj
+++ b/API/API.csproj
@@ -9,6 +9,7 @@
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="11.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.4.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="10.4.0" />
     <PackageReference Include="MediatR" Version="10.0.1" />

--- a/API/ApiResponses/ApiResponse.cs
+++ b/API/ApiResponses/ApiResponse.cs
@@ -1,0 +1,26 @@
+﻿namespace API.ApiResponses;
+
+public class ApiResponse
+{
+    public int StatusCode { get; set; }
+
+    public string? Message { get; set; }
+
+    public ApiResponse(int statusCode, string? message = null)
+    {
+        StatusCode = statusCode;
+        Message = message ?? GetDefaultMessageForStatusCode(statusCode);
+    }
+
+    private static string? GetDefaultMessageForStatusCode(int statusCode)
+    {
+        return statusCode switch
+        {
+            400 => "A bad request have been sent.",
+            401 => "Authorization have failed.",
+            404 => "The resource haven't been found.",
+            500 => "A bad thing have happend.",
+            _ => null
+        };
+    }
+}

--- a/API/ApiResponses/ApiValidationErrorResponse.cs
+++ b/API/ApiResponses/ApiValidationErrorResponse.cs
@@ -1,0 +1,12 @@
+﻿using FluentValidation.Results;
+
+namespace API.ApiResponses;
+
+public partial class ApiValidationErrorResponse : ApiResponse
+{
+    public ApiValidationErrorResponse() : base(400)
+    {
+    }
+
+    public IEnumerable<string> Errors { get; set; }
+}

--- a/API/Behaviors/BadRequestExceptionFilter.cs
+++ b/API/Behaviors/BadRequestExceptionFilter.cs
@@ -1,0 +1,21 @@
+﻿using API.ApiResponses;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using System.Net;
+
+namespace API.Behaviors;
+
+public class BadRequestExceptionFilter : IExceptionFilter
+{
+    public void OnException(ExceptionContext context)
+    {
+        if (context.Exception is BadHttpRequestException ex)
+        {
+            var errorResponse = new ApiResponse((int)HttpStatusCode.BadRequest, ex.Message);
+
+            context.Result = new BadRequestObjectResult(errorResponse);
+
+            context.ExceptionHandled = true;
+        }
+    }
+}

--- a/API/Behaviors/FluentValidationExceptionFilter.cs
+++ b/API/Behaviors/FluentValidationExceptionFilter.cs
@@ -1,0 +1,21 @@
+﻿using API.ApiResponses;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace API.Behaviors;
+
+public class FluentValidationExceptionFilter : IExceptionFilter
+{
+    public void OnException(ExceptionContext context)
+    {
+        if (context.Exception is ValidationException ex)
+        {
+            var errorResponse = new ApiValidationErrorResponse { Errors = ex.Errors.Select(e => e.ErrorMessage).ToList() };
+
+            context.Result = new BadRequestObjectResult(errorResponse);
+
+            context.ExceptionHandled = true;
+        }
+    }
+}

--- a/API/Behaviors/ValidationBehavior.cs
+++ b/API/Behaviors/ValidationBehavior.cs
@@ -1,0 +1,36 @@
+﻿using FluentValidation;
+using MediatR;
+
+namespace API.Behaviors;
+
+public class ValidationBehavior<TRequest, TResponse> : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
+{
+    private readonly IEnumerable<IValidator<TRequest>> _validators;
+
+    public ValidationBehavior(IEnumerable<IValidator<TRequest>> validators)
+    {
+        _validators = validators;
+    }
+
+    public async Task<TResponse> Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate<TResponse> next)
+    {
+        if (!_validators.Any())
+        {
+            return await next();
+        }
+
+        var context = new ValidationContext<TRequest>(request);
+
+        var failures = _validators.Select(v => v.Validate(context))
+            .SelectMany(result => result.Errors)
+            .Where(f => f != null)
+            .ToList();
+
+        if (failures.Count != 0)
+        {
+            throw new ValidationException(failures);
+        }
+
+        return await next();
+    }
+}

--- a/API/Extensions/ApplicationServicesExtensions.cs
+++ b/API/Extensions/ApplicationServicesExtensions.cs
@@ -1,4 +1,4 @@
-﻿using API.Data;
+using API.Data;
 using FluentValidation.AspNetCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -11,7 +11,13 @@ public static class ApplicationServicesExtensions
 {
     public static IServiceCollection AddApplicationServices(this IServiceCollection services, IConfiguration config, Assembly assembly)
     {
-        services.AddControllers().AddFluentValidation(cfg => cfg.RegisterValidatorsFromAssembly(assembly));
+        var currentAssembly = Assembly.GetExecutingAssembly();
+
+        services.AddControllers(opt =>
+        {
+            opt.Filters.Add<FluentValidationExceptionFilter>();
+            opt.Filters.Add<BadRequestExceptionFilter>();
+        });
 
         services.AddEndpointsApiExplorer();
 
@@ -21,7 +27,9 @@ public static class ApplicationServicesExtensions
         });
 
         services.AddAutoMapper(assembly);
+        services.AddTransient(typeof(IPipelineBehavior<,>), typeof(ValidationBehavior<,>));
 
+        services.AddValidatorsFromAssembly(currentAssembly);
         services.AddDbContext<ApiDbContext>(opt => opt.UseInMemoryDatabase("Tournament4YouDb").ConfigureWarnings(builder => builder.Ignore(InMemoryEventId.TransactionIgnoredWarning)));
 
         return services;


### PR DESCRIPTION
Basic response files were added, together with two exception filters - one for fluent validation, the second for throwing BadHttpRequest from miediatR handlers.